### PR TITLE
Avoid using dynamic table names in migration

### DIFF
--- a/db/migrations/20170527144759_add_historic_actions_table.php
+++ b/db/migrations/20170527144759_add_historic_actions_table.php
@@ -1,8 +1,6 @@
 <?php
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Historic\Action;
-
 class AddHistoricActionsTable extends AbstractMigration
 {
 		/**
@@ -29,7 +27,7 @@ class AddHistoricActionsTable extends AbstractMigration
 		public function change(){
 			if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 				$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-				$t = $this->table(Action::getTableName(), ['id' => false, 'primary_key' => 'id']);
+				$t = $this->table('historic_actions', ['id' => false, 'primary_key' => 'id']);
 				switch($strategy){
 					case 'mysql':
 						$t->addColumn('id', 'char', ['limit' => 36])
@@ -49,7 +47,7 @@ class AddHistoricActionsTable extends AbstractMigration
 				}
 			}
 			else{
-				$t = $this->table(Action::getTableName());
+				$t = $this->table('historic_actions');
 				$t->addColumn('historisable_type', 'char', ['limit' => 60])
 					->addColumn('historisable_id', 'integer')
 					->addColumn('historisable_ref_type', 'char', ['limit' => 60, 'null' => true])

--- a/db/migrations/20170527145337_add_historic_changes_table.php
+++ b/db/migrations/20170527145337_add_historic_changes_table.php
@@ -1,8 +1,6 @@
 <?php
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Historic\Change;
-
 class AddHistoricChangesTable extends AbstractMigration
 {
 	/**
@@ -29,7 +27,7 @@ class AddHistoricChangesTable extends AbstractMigration
 	public function change(){
 		if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 			$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-			$t = $this->table(Change::getTableName(), ['id' => false, 'primary_key' => 'id']);
+			$t = $this->table('historic_changes', ['id' => false, 'primary_key' => 'id']);
 			switch($strategy){
 				case 'mysql':
 					$t->addColumn('id', 'char', ['limit' => 36])
@@ -43,7 +41,7 @@ class AddHistoricChangesTable extends AbstractMigration
 			}
 		}
 		else{
-			$t = $this->table(Change::getTableName());
+			$t = $this->table('historic_changes');
 			$t->addColumn('action_id', 'integer');
 		}
 

--- a/db/migrations/20170706135537_allow_null_on_fields_before_after_in_changes.php
+++ b/db/migrations/20170706135537_allow_null_on_fields_before_after_in_changes.php
@@ -1,11 +1,9 @@
 <?php
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Historic\Change;
-
 class AllowNullOnFieldsBeforeAfterInChanges extends AbstractMigration{
 	public function change(){
-		$t = $this->table(Change::getTableName());
+		$t = $this->table('historic_changes');
 		$t->changeColumn('before', 'text', ['null' => true]);
 		$t->changeColumn('after', 'text', ['null' => true]);
 		$t->update();

--- a/phinx.php
+++ b/phinx.php
@@ -14,6 +14,7 @@ return array(
             'pass' => DB_PASSWORD,
             'charset' => 'utf8',
             'collation' => 'utf8_general_ci',
+            'table_prefix' => defined('DB_PREFIX') ? DB_PREFIX : 'pragma_',
         ),
     ),
 );


### PR DESCRIPTION
As class declarations table names might be changed  in further updates,
it would invalidate every previous migrations.